### PR TITLE
[UI 개선] 로그인 페이지 컴포넌트 정렬 및 높이 수정

### DIFF
--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -191,9 +191,10 @@ const AutoLoginContainer = styled.div`
 `;
 
 const StyledCheckbox = styled.input`
-    width: 14px;
-    height: 14px;
-    cursor: pointer;
+	width: 14px;
+	height: 14px;
+	cursor: pointer;
+	transform: translateY(-1px);
 `;
 
 const AutoLoginLabel = styled.label`
@@ -204,6 +205,7 @@ const AutoLoginLabel = styled.label`
     font-weight: 400;
     line-height: 168%;
     letter-spacing: -0.35px;
+	cursor: pointer;
 `;
 
 const HelpButton = styled.button`

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -93,7 +93,7 @@ const EmailContainer = styled.div`
 	display: flex;
 	width: 400px;
 	flex-direction: column;
-	gap: 4px;
+	gap: 8px;
 	padding-bottom: 20px;
 `;
 
@@ -101,7 +101,7 @@ const PwContainer = styled.div`
 	display: flex;
 	width: 400px;
 	flex-direction: column;
-	gap: 4px;
+	gap: 8px;
 	padding-bottom: 20px;
 `;
 
@@ -117,29 +117,33 @@ const InputLabel = styled.label`
 `;
 
 const StyledInput = styled.input`
-	display: flex;
+    display: flex;
+    width: 400px;
+    height: 48px;
+    padding: 12px 16px;
+    align-items: center;
+    gap: 8px;
+    border-radius: 12px;
+    background: var(--Colors-GrayScale-G200, #F3F5F8);
+    box-shadow: 0px 0px 8px 0px rgba(26, 26, 35, 0.12) inset;
+    border: none;
+    font-family: "SUIT Variable";
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 150%;
+    letter-spacing: -0.4px;
 
-	height: 48px;
-	padding: 12px 16px;
-	align-items: center;
-	gap: 8px;
-	align-self: stretch;
-	border-radius: 12px;
-	background: var(--Colors-GrayScale-G200, #F3F5F8);
-	box-shadow: 0px 0px 8px 0px rgba(26, 26, 35, 0.12) inset;
-	border: none;
-	
-
-	&::placeholder {
-		flex: 1 0 0;
-		color: var(--Colors-GrayScale-G400, #949BAD);
-		font-family: "SUIT Variable";
-		font-size: 16px;
-		font-style: normal;
-		font-weight: 500;
-		line-height: 150%;
-		letter-spacing: -0.4px;
-	}
+    &::placeholder {
+        color: var(--Colors-GrayScale-G400, #949BAD);
+        font-family: "SUIT Variable";
+        font-size: 16px;
+        font-style: normal;
+        font-weight: 500;
+        line-height: 150%;
+        letter-spacing: -0.4px;
+        vertical-align: middle;
+    }
 `;
 
 const PasswordGuide = styled.p`
@@ -151,7 +155,6 @@ const PasswordGuide = styled.p`
 	font-weight: 500;
 	line-height: 132%;
 	letter-spacing: -0.3px;
-	margin-top: 4px;
 `;
 
 const LoginButton = styled.button`
@@ -232,16 +235,17 @@ const DividerLine = styled.div`
 	width: 143px;
 	height: 1px;
 	background-color: var(--Colors-GrayScale-G300, #DDE1E7);
+	transform: translateY(-1px);
 `;
 
 const SnsButtonContainer = styled.div`
 	display: flex;
+	width: 400px;
 	flex-direction: row;
 	gap: 24px;
 	justify-content: center;
 	align-items: center;
 	padding-bottom: 52px;
-	width: 400px;
 `;
 
 const SnsLoginText = styled.span`


### PR DESCRIPTION
[UI 개선] 로그인 페이지 컴포넌트 정렬 및 높이 수정

### PR 타입
-[] 기능 추가
-[] 기능 삭제
-[✅] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
fix/login-design -> dev

### 변경 사항
1. 자동 로그인 영역 컴포넌트 정렬 수정
   - 체크박스, 라벨, 문제해결 버튼 높이 24px로 통일
   - 컴포넌트 간 수직 정렬 일치하도록 개선
   - 불필요한 여백 제거

2. 입력 필드 개선
   - placeholder 텍스트 수직 중앙 정렬
   - 입력 텍스트와 placeholder 폰트 크기 통일

3. SNS 로그인 섹션
   - 구분선과 텍스트 간 수직 정렬 개선
   - 구분선 위치 미세 조정

### 테스트 결과
- 자동 로그인 영역의 모든 컴포넌트가 동일 선상에 정렬됨
- placeholder 텍스트가 입력 필드 중앙에 위치
- SNS 로그인 구분선이 텍스트와 정확히 정렬됨
- 모든 컴포넌트가 디자인 가이드에 맞게 표시됨