### PR TITLE
[기능 추가] 회원가입 페이지 단계별 뒤로가기 구현

### DIFF
--- a/src/pages/SignupPages/SignupMain.jsx
+++ b/src/pages/SignupPages/SignupMain.jsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import SignupBackground from '../../components/SignupBackground';
 import SignupPage1 from './SignupPage1';
@@ -91,8 +91,31 @@ const SIGNUP_STEPS = {
 
 const SignupPage = () => {
 	const navigate = useNavigate();
+	const location = useLocation();
 	const [step, setStep] = useState(1);
 	const [verificationStatus, setVerificationStatus] = useState(false);
+
+	useEffect(() => {
+		window.history.pushState({ step }, '', location.pathname);
+
+		const handlePopState = (event) => {
+			if (event.state?.step) {
+				setStep(step > 1 ? step - 1 : 1);
+			} else {
+				if (window.confirm('회원가입을 취소하시겠습니까?')) {
+					navigate('/login');
+				} else {
+					window.history.pushState({ step }, '', location.pathname);
+				}
+			}
+		};
+
+		window.addEventListener('popstate', handlePopState);
+
+		return () => {
+			window.removeEventListener('popstate', handlePopState);
+		};
+	}, [step, navigate, location.pathname]);
 
 	const currentStep = SIGNUP_STEPS[step] || SIGNUP_STEPS[1];
 	const componentProps = {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[✅] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/signup-navigation -> dev

### 변경 사항
회원가입 페이지에서 브라우저 뒤로가기 시 이전 단계로 이동하는 기능을 구현했습니다.
- History API를 사용하여 회원가입 단계별 상태 관리
- 첫 단계에서 뒤로가기 시 사용자 확인 후 로그인 페이지로 이동

### 테스트 결과
- 각 단계별 뒤로가기 정상 작동 확인
- 첫 단계에서 뒤로가기 시 확인 창 표시 및 로그인 페이지 이동 확인
- 페이지 새로고침 시 현재 단계 유지 확인