### PR TITLE
[기능 수정] 회원가입 페이지 레이아웃 간격 조정

### DIFF
--- a/src/pages/SignupPages/SignupMain.jsx
+++ b/src/pages/SignupPages/SignupMain.jsx
@@ -6,9 +6,8 @@ import SignupPage1 from './SignupPage1';
 import SignupPage2 from './SignupPage2';
 import SignupPage3 from './SignupPage3';
 import SignupPage4 from './SignupPage4';
-// import SignupPage5 from './SignupPage5';
+import SignupPage5Main from './SignupPage5Main';
 import SignupPage6 from './SignupPage6';
-import SignupPage5 from './SignupPage5Main';
 
 const PageContainer = styled.div`
 	display: flex;
@@ -82,7 +81,7 @@ const SIGNUP_STEPS = {
 	5: {
 		header: "거의 다 왔어요!",
 		subtitle: "서비스에서 이용할 정보를 입력해주세요.",
-		component: (props) => <SignupPage5 {...props} />
+		component: (props) => <SignupPage5Main {...props} />
 	},
 	6: {
 		header: "회원가입을 완료했어요!",

--- a/src/pages/SignupPages/SignupPage5Main.jsx
+++ b/src/pages/SignupPages/SignupPage5Main.jsx
@@ -33,6 +33,18 @@ const TypeButton = styled.button`
 `;
 
 // 공통 스타일 컴포넌트들
+
+// 입력 섹션
+export const InputSection = styled.div`
+    margin-top: 32px;
+`;
+
+// 입력 래퍼
+export const InputWrapper = styled.div`
+    position: relative;
+    width: 100%;
+`;
+
 // 라벨
 export const Label = styled.label`
     display: block;
@@ -51,7 +63,6 @@ export const InputContainer = styled.div`
     display: flex;
     gap: 8px;
     width: 100%;
-    margin-bottom: 12px;
 `;
 
 // 입력 필드
@@ -208,6 +219,7 @@ export const SignupButton = styled(BlueButton)`
 `;
 
 
+
 // 유효성 검사 함수들
 export const validators = {
     validateUserId: (id) => {
@@ -325,12 +337,11 @@ export const useTimer = () => {
 };
 
 const SignupPage5Main = ({ setStep }) => {
-    const [showEmailInput, setShowEmailInput] = useState(false);
+    const [showEmailInput, setShowEmailInput] = useState(true);
     const [showBusinessInput, setShowBusinessInput] = useState(false);
 
     return (
         <div>
-            {/* 타입 버튼 */}
             <ButtonContainer>
                 <TypeButton 
                     active={showEmailInput}
@@ -352,7 +363,6 @@ const SignupPage5Main = ({ setStep }) => {
                 </TypeButton>
             </ButtonContainer>
 
-            {/* 타입에 따라 컴포넌트 렌더링 */}
             {showEmailInput && <SignupPage5_enterprise setStep={setStep} />}
             {showBusinessInput && <SignupPage5_business setStep={setStep} />}
         </div>


### PR DESCRIPTION
### PR 타입
-[] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[✅] UI/UX 개선

### 반영 브랜치
style/signup -> dev

### 변경 사항
- Label과 Input 컴포넌트 사이의 간격을 8px로 통일
- 기존 margin 값 수정 (margin: 20px 0 8px 0 -> margin-bottom: 8px)
- 디자인 시스템의 일관성 확보

### 테스트 결과
- 회원가입 페이지의 모든 Label과 Input 컴포넌트 간격이 8px로 정상 적용됨
- 다른 컴포넌트들과의 레이아웃 충돌 없음