### PR TITLE
[기능 수정] 회원가입 페이지 레이아웃 간격 조정

### DIFF
--- a/src/pages/SignupPages/SignupPage5Main.jsx
+++ b/src/pages/SignupPages/SignupPage5Main.jsx
@@ -55,7 +55,7 @@ export const Label = styled.label`
     font-weight: 500;
     line-height: 168%;
     letter-spacing: -0.35px;
-    margin: 20px 0 8px 0;
+    margin-top : 20px;
 `;
 
 // 입력 컨테이너
@@ -63,6 +63,7 @@ export const InputContainer = styled.div`
     display: flex;
     gap: 8px;
     width: 100%;
+    margin-top: 8px;
 `;
 
 // 입력 필드


### PR DESCRIPTION
### PR 타입
-[] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[✅] UI/UX 개선

### 반영 브랜치
style/signup -> dev

### 변경 사항
- Label과 Input 컴포넌트 사이의 간격을 8px로 통일
- 기존 margin 값 수정 (margin: 20px 0 8px 0 -> margin-bottom: 8px)
- 디자인 시스템의 일관성 확보

### 테스트 결과
- 회원가입 페이지의 모든 Label과 Input 컴포넌트 간격이 8px로 정상 적용됨
- 다른 컴포넌트들과의 레이아웃 충돌 없음