### PR TITLE
[UI/UX 개선] 주민등록번호 입력 필드 레이아웃 개선

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,38 +1,38 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import react from 'eslint-plugin-react'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
+import js from "@eslint/js";
+import globals from "globals";
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
 
 export default [
-  { ignores: ['dist'] },
+  { ignores: ["dist"] },
   {
-    files: ['**/*.{js,jsx}'],
+    files: ["**/*.{js,jsx}"],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
       parserOptions: {
-        ecmaVersion: 'latest',
+        ecmaVersion: "latest",
         ecmaFeatures: { jsx: true },
-        sourceType: 'module',
+        sourceType: "module",
       },
     },
-    settings: { react: { version: '18.3' } },
+    settings: { react: { version: "18.3" } },
     plugins: {
       react,
-      'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
     },
     rules: {
       ...js.configs.recommended.rules,
       ...react.configs.recommended.rules,
-      ...react.configs['jsx-runtime'].rules,
+      ...react.configs["jsx-runtime"].rules,
       ...reactHooks.configs.recommended.rules,
-      'react/jsx-no-target-blank': 'off',
-      'react-refresh/only-export-components': [
-        'warn',
+      "react/jsx-no-target-blank": "off",
+      "react-refresh/only-export-components": [
+        "warn",
         { allowConstantExport: true },
       ],
     },
   },
-]
+];

--- a/src/pages/SignupPages/SignupPage3.jsx
+++ b/src/pages/SignupPages/SignupPage3.jsx
@@ -51,10 +51,14 @@ const StyledInput = styled.input`
     }
 `;
 
-const SSNWrapper = styled.div`
+export const SSNWrapper = styled.div`
     display: flex;
+    justify-content: space-between;
     align-items: center;
-    gap: 8px;
+    
+    img {
+        margin: 0 8px;
+    }
 `;
 
 const SSNStyledInput = styled(StyledInput)`


### PR DESCRIPTION
### PR 타입
-[] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[✅] UI/UX 개선

### 반영 브랜치
design/ssn-input-layout -> dev

### 변경 사항
- 주민등록번호 입력 필드의 레이아웃을 개선했습니다
  - 앞자리(6자리) 입력 필드: 왼쪽 정렬
  - 뒷자리(7자리) 입력 필드: 오른쪽 정렬
  - 중앙 대시(-) 이미지: 적절한 여백 유지

### 테스트 결과
- 입력 필드의 정렬이 디자인 의도대로 적용되었습니다
- 반응형 레이아웃에서도 정상적으로 동작합니다